### PR TITLE
WINDUP-2274 Scripts for local build of CLI and Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # windup-local-build-scripts
 Useful scripts to build locally all projects involving the RHAMT CLI and Web UI
+
+The scripts within this repository should be executed from the parent directory of the local repositories, i.e. the parent directory of windup, windup-distribution, etc.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The scripts within this repository should be executed from the parent directory 
 
 Execute the scripts via the following commands (please ensure the Docker daemon is running before executing the build_web.sh)
 
-./windup-local-build-scripts/build_cli.sh
+ `$ ./windup-local-build-scripts/build_cli.sh`
 
 ./windup-local-build-scripts/build_web.sh
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 Useful scripts to build locally all projects involving the RHAMT CLI and Web UI
 
 The scripts within this repository should be executed from the parent directory of the local repositories, i.e. the parent directory of windup, windup-distribution, etc.
+
+Execute the scripts via the following commands (please ensure the Docker daemon is running before executing the build_web.sh)
+
+./windup-local-build-scripts/build_cli.sh
+
+./windup-local-build-scripts/build_web.sh
+

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Execute the scripts via the following commands (please ensure the Docker daemon 
 
  `$ ./windup-local-build-scripts/build_cli.sh`
 
-./windup-local-build-scripts/build_web.sh
+ `$ ./windup-local-build-scripts/build_web.sh`
 

--- a/build_cli.sh
+++ b/build_cli.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
-cd ../windup
-mvn -DskipTests clean install
-cd ../windup-rulesets
-mvn -DskipTests clean install
-cd ../windup-distribution
-mvn -DskipTests clean install
+
+readonly MVN_COMMAND="mvn clean install -DskipTests"
+
+cd windup
+$MVN_COMMAND || exit 1
+cd ..
+
+cd windup-rulesets
+$MVN_COMMAND || exit 1
+cd ..
+
+cd windup-distribution
+$MVN_COMMAND || exit 1
+
 cd target
 unzip rhamt-cli-*.zip

--- a/build_cli.sh
+++ b/build_cli.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#Run this script from the parent directory of the local Repo directories listed below
+
 readonly MVN_COMMAND="mvn clean install -DskipTests"
 
 cd windup

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+#Run this script from the parent directory of the local Repo directories listed below
+
 #Before running this script ensure the docker daemon is running
 
 readonly MVN_COMMAND="mvn clean install -DskipTests"

--- a/build_web.sh
+++ b/build_web.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
-cd ../windup-web
-mvn -DskipTests clean install
-cd ../windup-openshift
-mvn -DskipTests clean install
-cd ../windup-web-distribution
-mvn -DskipTests clean install
+
+#Before running this script ensure the docker daemon is running
+
+readonly MVN_COMMAND="mvn clean install -DskipTests"
+
+cd windup-web
+$MVN_COMMAND || exit 1
+cd ..
+
+cd windup-openshift
+$MVN_COMMAND || exit 1
+cd ..
+
+cd windup-web-distribution
+$MVN_COMMAND || exit 1
+
 cd target
+
 unzip rhamt-web-*.zip


### PR DESCRIPTION
Run the scripts from the parent folder to your cloned repositories

The build_cli.sh expects the windup, windup-rulesets and windup-distribution projects to have been cloned.

The build_web.sh expects the windup-web, windup-openshift and windup-web-distribution projects to have been cloned.

For the build_web.sh please ensure that you have the docker daemon running